### PR TITLE
feat(cdk8s): storageClassName injection

### DIFF
--- a/packages/chainfile-cdk8s/src/chart.ts
+++ b/packages/chainfile-cdk8s/src/chart.ts
@@ -24,6 +24,7 @@ export interface CFChartProps {
 
   spec: {
     replicas?: number;
+    storageClassName?: string;
 
     /**
      * Ports to expose on the service.
@@ -80,6 +81,11 @@ export class CFChart extends Chart {
         replicas: props.spec.replicas,
         selector: {
           matchLabels: labels,
+        },
+        volumeClaimTemplates: {
+          spec: {
+            storageClassName: props.spec.storageClassName,
+          },
         },
       },
     });

--- a/packages/chainfile-cdk8s/src/sts.ts
+++ b/packages/chainfile-cdk8s/src/sts.ts
@@ -15,6 +15,12 @@ export interface CFStatefulSetProps {
     readonly template?: Omit<PodTemplateSpec, 'spec'> & {
       readonly spec?: Omit<PodSpec, 'hostAliases' | 'volumes' | 'containers'>;
     };
+    readonly volumeClaimTemplates?: {
+      readonly metadata?: Omit<ObjectMeta, 'name'>;
+      readonly spec?: {
+        readonly storageClassName?: string;
+      };
+    };
   };
 }
 
@@ -72,9 +78,11 @@ export class CFStatefulSet extends KubeStatefulSet {
           .map(([volumeName, volume]) => {
             return {
               metadata: {
+                ...props.spec.volumeClaimTemplates?.metadata,
                 name: Names.toDnsLabel(scope, { extra: ['pvc', volumeName] }),
               },
               spec: CFPersistentVolumeClaimSpec({
+                storageClassName: props.spec.volumeClaimTemplates?.spec?.storageClassName,
                 volume: volume,
               }),
             };

--- a/packages/chainfile-cdk8s/src/volume.ts
+++ b/packages/chainfile-cdk8s/src/volume.ts
@@ -13,9 +13,13 @@ export function CFEphemeralVolume(props: { name: string; volume: schema.Volume }
   };
 }
 
-export function CFPersistentVolumeClaimSpec(props: { volume: schema.Volume }): PersistentVolumeClaimSpec {
+export function CFPersistentVolumeClaimSpec(props: {
+  storageClassName?: string;
+  volume: schema.Volume;
+}): PersistentVolumeClaimSpec {
   return {
     accessModes: ['ReadWriteOnce'],
+    storageClassName: props.storageClassName,
     resources: {
       requests: {
         storage: calculateStorage(props.volume, {


### PR DESCRIPTION
#### What this PR does / why we need it:

Add the ability to set storageClassName for SST.
This isn't necessarily required since the value can defaulted on cluster.